### PR TITLE
Fix bug with deploy job when .git directory doesn't exist

### DIFF
--- a/src/scripts/deploy.sh
+++ b/src/scripts/deploy.sh
@@ -2,7 +2,12 @@ Setup() {
     U=$(eval echo "$USERNAME")
     R=$(eval echo "$REPONAME")
     GIT_URL="git@${GIT_HOST}:${U}/${R}.git"
-    MESSAGE="Built artifacts of $(git rev-parse --short HEAD) [ci skip]"
+	if [[ -d ./.git ]]
+	then
+		MESSAGE="Built artifacts of $(git rev-parse --short HEAD) [ci skip]"
+	else
+		MESSAGE="Built artifacts of latest commit [ci skip]"
+	fi
 }
 
 SetCommitMessage() {


### PR DESCRIPTION
I was attempting to use this orb by building my frontend app in another job and just attaching the `dist/` directory via the workspace. In doing so, I discovered that the default message relies on an existing git repository when it runs `git rev-parse`. This change updates the setup logic to check for the existence of the .git directory before using rev-parse so the job doesn't crash in the absence of a git repo.